### PR TITLE
Fix uptime in health check

### DIFF
--- a/app.py
+++ b/app.py
@@ -897,7 +897,8 @@ def health_check():
     health_status = {
         'status': 'healthy',
         'timestamp': datetime.now().isoformat(),
-        'uptime': time.process_time(),
+        # Use wall clock time instead of CPU process time for uptime
+        'uptime': (datetime.now() - stats['start_time']).total_seconds(),
         'gpio_initialized': len(initialized_pins) > 0,
         'errors_last_minute': 0  # Could implement rolling error count
     }


### PR DESCRIPTION
## Summary
- calculate uptime based on wall clock time instead of CPU time

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688aa105e9ac8332b52649fd2b85536d